### PR TITLE
Make vsc and Discord hyperlinks point directly to the download page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This project is made by using a package named ```discord-rpc``` you can view it'
 #### Make sure you have these 4 things installed in your system:
 [Node.js](https://nodejs.org/en/download/)
 
-[Visual Studio Code](https://code.visualstudio.com/)
+[Visual Studio Code](https://code.visualstudio.com/Download)
 
 [Git](https://git-scm.com/downloads)
 
-[Discord](https://discord.com/)
+[Discord](https://discord.com/download)
 ## How to setup 
 ◙ Go to discord developer portal by [clicking here](https://discord.com/developers/applications) and then go to the top left corner of your screen see create application and then name it.
 #### And hey the name of the application shold be the name of the presence that u wanna give for example if you wanna keep your status playing Myself then you have to name your application Myself


### PR DESCRIPTION
Right now the hyperlinks for Discord and Visual Studio Code in the README point to the main pages whereas the hyperlinks for the other sites, Git and Node.js, direct to their download pages. This pull request changes the links to direct to the applications' download pages.